### PR TITLE
Fix opposite unprotected display message:

### DIFF
--- a/scripting/spawnandkillprotection.sp
+++ b/scripting/spawnandkillprotection.sp
@@ -577,6 +577,8 @@ DisableKillProtection(client)
 		return;
 	}
 
+	NotifyClientDisableProtection(client);
+
 	isKillProtected[client] =  false;
 	isSpawnKillProtected[client] = false;
 	isWallKillProtected[client] = false;
@@ -594,8 +596,6 @@ DisableKillProtection(client)
 	if (GetConVarBool(fadescreen)) {
 		Client_ScreenFade(client, 0, FFADE_IN | FFADE_PURGE, -1, 0, 0, 0, 0);
 	}
-
-	NotifyClientDisableProtection(client);
 }
 
 DisableKillProtectionAll()


### PR DESCRIPTION
When becoming active (de-protected) after spawning, the generic "Killprotection Disabled" was displayed to the client instead of "Spawnprotection Disabled", as it should (under `sakp_notify` modes `2` and `3`). This was caused by mistakenly early zeroing the isSpawnKillProtected control variable for the client, that prevents the intended check at NotifyClientDisableProtection to pass.