### PR TITLE
Enhance plugin demanding & API native

### DIFF
--- a/scripting/include/spawnandkillprotection.inc
+++ b/scripting/include/spawnandkillprotection.inc
@@ -4,21 +4,24 @@
 #endif
 #define _sakprotection_included_
 
-
 public SharedPlugin:__pl_sakprotection = 
 {
-	name = "Spawn & Kill protection",
+	name = "sakprotection",
 	file = "spawnandkillprotection.smx",
+
+#if (defined REQUIRE_PLUGIN)
+	required = 1
+#else
 	required = 0
+#endif // REQUIRE_PLUGIN
 };
 
-
+#if (!defined REQUIRE_PLUGIN)
 public __pl_sakprotection_SetNTVOptional()
 {
 	MarkNativeAsOptional("SAKP_IsClientProtected");
 }
-
-
+#endif // !REQUIRE_PLUGIN
 
 /**
  * Returns if a client is currently protected.

--- a/scripting/include/spawnandkillprotection.inc
+++ b/scripting/include/spawnandkillprotection.inc
@@ -27,6 +27,7 @@ public __pl_sakprotection_SetNTVOptional()
  * Returns if a client is currently protected.
  *
  * @param client    Client index.
+ * @param wall      True if client is wall-protected, false otherwise.
  * @return          Returns true if the client is protected otherwise false.
  */
-native bool:SAKP_IsClientProtected(client);
+native bool:SAKP_IsClientProtected(client, &bool:wall = false);

--- a/scripting/spawnandkillprotection.sp
+++ b/scripting/spawnandkillprotection.sp
@@ -87,9 +87,10 @@ new Handle:hudSynchronizer                  = INVALID_HANDLE;
 *****************************************************************/
 
 public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
-{	
-   CreateNative("SAKP_IsClientProtected", Native_IsClientProtected);
-   return APLRes_Success;
+{
+	RegPluginLibrary("sakprotection");
+	CreateNative("SAKP_IsClientProtected", Native_IsClientProtected);
+	return APLRes_Success;
 }
 
 public OnPluginStart()

--- a/scripting/spawnandkillprotection.sp
+++ b/scripting/spawnandkillprotection.sp
@@ -500,9 +500,9 @@ Float:GetKeyPressIgnoreTime(client)
 
 public Native_IsClientProtected(Handle:plugin, numParams)
 {
-	new bool:isClientProtected = GetNativeCell(1);
-
-	return isKillProtected[isClientProtected];
+	new client = GetNativeCell(1);
+	SetNativeCellRef(2, isWallKillProtected[client]);
+	return isKillProtected[client];
 }
 
 CreateTestHudSynchronizer()

--- a/scripting/spawnandkillprotection.sp
+++ b/scripting/spawnandkillprotection.sp
@@ -128,9 +128,9 @@ public OnPluginStart()
 	keypressignoretime       = Sakp_CreateConVar("keypressignoretime", "0.8", "The amount of time in seconds pressing any keys will not turn off spawn protection");
 	keypressignoretime_team1 = Sakp_CreateConVar("keypressignoretime_team1", "-1", "same as sakp_keypressignoretime, but for team 1 only (overrides sakp_keypressignoretime if not set to -1)");
 	keypressignoretime_team2 = Sakp_CreateConVar("keypressignoretime_team2", "-1", "same as sakp_keypressignoretime, but for team 1 only (overrides sakp_keypressignoretime if not set to -1)");
-	maxspawnprotection       = Sakp_CreateConVar("maxspawnprotection", "0", "max timelimit in seconds the spawnprotection stays, 0 = no limit",FCVAR_PLUGIN);
-	maxspawnprotection_team1 = Sakp_CreateConVar("maxspawnprotection_team1", "-1", "same as sakp_maxspawnprotection, but for team 1 only (overrides sakp_maxspawnprotection if not set to -1)",FCVAR_PLUGIN);
-	maxspawnprotection_team2 = Sakp_CreateConVar("maxspawnprotection_team2", "-1", "same as sakp_maxspawnprotection, but for team 2 only (overrides sakp_maxspawnprotection if not set to -1)",FCVAR_PLUGIN);
+	maxspawnprotection       = Sakp_CreateConVar("maxspawnprotection", "0", "max timelimit in seconds the spawnprotection stays, 0 = no limit");
+	maxspawnprotection_team1 = Sakp_CreateConVar("maxspawnprotection_team1", "-1", "same as sakp_maxspawnprotection, but for team 1 only (overrides sakp_maxspawnprotection if not set to -1)");
+	maxspawnprotection_team2 = Sakp_CreateConVar("maxspawnprotection_team2", "-1", "same as sakp_maxspawnprotection, but for team 2 only (overrides sakp_maxspawnprotection if not set to -1)");
 	fadescreen               = Sakp_CreateConVar("fadescreen", "1", "Fade screen to black");
 	hidehud                  = Sakp_CreateConVar("hidehud", "1", "Set to 1 to hide the HUD when being protected");
 	player_color_r           = Sakp_CreateConVar("player_color_red", "255", "amount of red when a player is protected 0-255");
@@ -696,5 +696,5 @@ Handle:Sakp_CreateConVar(
 	Format(newName, sizeof(newName), "sakp_%s", name);
 	Format(newDescription, sizeof(newDescription), "Sourcemod Spawn & kill protection plugin:\n%s", description);
 
-	return CreateConVar(newName, defaultValue, newDescription, flags | FCVAR_PLUGIN, hasMin, min, hasMax, max);
+	return CreateConVar(newName, defaultValue, newDescription, flags, hasMin, min, hasMax, max);
 }


### PR DESCRIPTION
Hi,

So I had the need to check in a custom plugin (which integrates with S&KP) if kill protected clients are exclusively spawn based, and for this, I had the idea to expand the native with a new by-ref parameter to retrieve whether clients are wall-protected (for my use case it would be a micro-optimization to parametrize for spawn protection instead, but for general convenience I thought it was better otherwise). You can see that the new parameter is optional so none must fill it.

The PR also clears warnings from modern SP compiler (I hope that's just fine).

@berni2288 **UPDATE 09/26/2021**: This PR now also includes an enhancement to the plugin demanding options, which I found convenient for a self integrating plugin. The API header has been improved in that it now supports dependency injection with `required = 1` mode, following SM standards, for users who want it.

Waiting for you to let me know if this proposal is generic enough for you and acceptable. Thanks.