### PR TITLE
Fix kill protection not removing when going spectate

### DIFF
--- a/scripting/spawnandkillprotection.sp
+++ b/scripting/spawnandkillprotection.sp
@@ -143,6 +143,7 @@ public OnPluginStart()
 
 	HookEvent("player_spawn", Event_PlayerSpawn);
 	HookEvent("player_death", Event_PlayerDeath);
+	HookEvent("player_team", Event_PlayerDeath); // Reuse callback, valid for our needs
 
 	// Hooking the existing clients in case of lateload
 	LOOP_CLIENTS(client, CLIENTFILTER_INGAME | CLIENTFILTER_NOBOTS) {


### PR DESCRIPTION
This completely fixes an obvious mistake that only recently found on my deathmatch server, as someone went to spectate and I hadn't had the need to do as well (the `player_death` callback isn't called when moving to spectate, normally).

If you don't find the simple approach taken convenient, let me know.

Thanks.